### PR TITLE
USI support patch

### DIFF
--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Command.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Command.cfg
@@ -1,0 +1,226 @@
+//
+// common MKS modules for the rover command module
+//
+@PART[Benjee10_MMSEV]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// can help with EVA construction
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionForeman
+	}
+	
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionHelper
+		KonstructionPoints = 4
+	}
+	
+	// can participate in local logistics
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+	
+	// can help with distribution of local logistics (2km scavenging extension)
+	MODULE
+	{
+		name = ModuleResourceDistributor
+	}
+}
+
+//
+// adds remote power reception for the chassis. This is a bit questionable
+// so feel free to remove it if you think the rover receiving microwave power
+// from the base to its chassis doesn't make sense. In MKS this is done via
+// a separate small antenna part that can be attached to anything.
+//
+@PART[Benjee10_MMSEV_chassis]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// receives remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+}
+
+//
+// common MKS modules for the command cabin
+//
+@PART[Benjee10_MMSEV_baseLander]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// receives remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+	
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// can help with EVA construction
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionForeman
+	}
+	
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionHelper
+		KonstructionPoints = 4
+	}
+	
+	// can participate in local logistics
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+	
+	// can help with distribution of local logistics (2km scavenging extension)
+	MODULE
+	{
+		name = ModuleResourceDistributor
+	}
+	
+	// can participate in planetary logistics
+	MODULE
+	{
+		name = ModulePlanetaryLogistics
+	}
+}
+
+
+//
+// bonuses for the largest command node module
+//
+@PART[Benjee10_MMSEV_baseHDU]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// receives remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+	
+	// sends power to remote consumers
+	MODULE
+ 	{
+ 		name = ModulePowerDistributor
+ 	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+	
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// can help with EVA construction
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionForeman
+	}
+	
+	MODULE:NEEDS[Konstruction]
+	{
+		name = ModuleKonstructionHelper
+		KonstructionPoints = 8
+	}
+	
+	// can participate in local logistics
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+	
+	MODULE
+	{
+		name = ModuleResourceDistributor
+	}
+	
+	// can participate in planetary logistics
+	MODULE
+	{
+		name = ModulePlanetaryLogistics
+	}
+	
+	// the central hub is big so it can participate in orbital logistics too
+	MODULE
+	{
+		name = ModuleOrbitalLogistics
+	}
+	
+	// and for that we need to be able to produce transport credits
+	MODULE
+	{
+		name = USI_Converter
+		ConverterName = TransportCredits
+		StartActionName = Start T-Credits
+		StopActionName = Stop T-Credits
+
+		UseSpecialistBonus = false
+		IsStandaloneConverter = true
+		Efficiency = 1
+
+		INPUT_RESOURCE
+		{
+			ResourceName = MaterialKits
+			Ratio = 0.2
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = LiquidFuel
+			Ratio = 0.45
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Oxidizer
+			Ratio = 0.55
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 10
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = TransportCredits
+			Ratio = 1
+			DumpExcess = false
+		}
+	}
+	
+	RESOURCE
+	{
+		name = TransportCredits
+		amount = 0
+		maxAmount = 100000
+		isTweakable = false
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Containers.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Containers.cfg
@@ -1,0 +1,10 @@
+//
+// adds local logistics for the service module
+//
+@PART[Benjee10_MMSEV_monopropSled]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	MODULE
+	{
+		name = USI_ModuleResourceWarehouse
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Converters.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Converters.cfg
@@ -1,0 +1,360 @@
+//
+// bonuses and converters for the hydroponics module
+//
+@PART[Benjee10_MMSEV_baseGreenhouse]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+	
+	// receives remote power
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+	
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = ScienceBoost
+		EfficiencyMultiplier = 1.5
+	}
+	
+	// can participate in local logistics
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+
+	// this module is closest to Tundra_Agriculture250 in terms of mass, so the converters 
+	// below are straight copies from that part. A balance pass here would be useful. 
+	
+	MODULE
+	{
+		name = USI_SwapController
+		ResourceCosts = SpecializedParts,8,MaterialKits,40,ElectricCharge,40	
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Agroponics
+		StartActionName = Start Agroponics
+		StopActionName = Stop Agroponics
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = BotanySkill
+		EfficiencyTag = Greenhouse
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Mulch
+			Ratio =  0.00210000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00021000
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Supplies
+			Ratio = 0.00231000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 4.62
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000002
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000002
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 100
+		}
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Cultivate(S)
+		StartActionName = Start Cultivate(S)
+		StopActionName = Stop Cultivate(S)
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = BotanySkill
+		EfficiencyTag = Greenhouse
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Substrate
+			Ratio =  0.00430000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio =  0.00430000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00004300
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Supplies
+			Ratio = 0.00043000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 9.07
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000002
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000002
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 100
+		}
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Cultivate(D)
+		StartActionName = Start Cultivate(D)
+		StopActionName = Stop Cultivate(D)
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = BotanySkill
+		EfficiencyTag = Greenhouse
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Dirt
+			Ratio =  0.00450000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio =  0.00450000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00001800
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Supplies
+			Ratio = 0.00018000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 9.2
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000002
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000002
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 100
+		}
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Agriculture(S)
+		StartActionName = Start Agriculture(S)
+		StopActionName = Stop Agriculture(S)
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = AgronomySkill
+		EfficiencyTag = Greenhouse
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Substrate
+			Ratio =  0.00375000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio =  0.00375000
+		}
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00001500
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Organics
+			Ratio = 0.00045000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 8.57
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000002
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000002
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 100
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Organics
+			Ratio = 100
+		}		
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Agriculture(D)
+		StartActionName = Start Agriculture(D)
+		StopActionName = Stop Agriculture(D)
+		
+		UseSpecialistBonus = true
+		ExperienceEffect = AgronomySkill
+		EfficiencyTag = Greenhouse
+		
+		INPUT_RESOURCE
+		{
+			ResourceName = Dirt
+			Ratio =  0.00415000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio =  0.00415000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00000830
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Organics
+			Ratio = 0.000083
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 9.06
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000002
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000002
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 100
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Organics
+			Ratio = 100
+		}
+	}
+	
+	// RESOURCES
+	
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 1000
+		maxAmount = 1000
+	}
+	RESOURCE
+	{
+		name = Machinery
+		amount = 100
+		maxAmount = 100
+		isTweakable = true
+	}
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 100
+		isTweakable = true
+	}
+	RESOURCE
+	{
+		name = Organics
+		amount = 0
+		maxAmount = 100
+		isTweakable = true
+	}
+	
+	
+}

--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Converters.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Converters.cfg
@@ -63,33 +63,33 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Mulch
-			Ratio =  0.00210000
+			Ratio =  0.00140000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00021000
+			Ratio =  0.00014000
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.00231000
+			Ratio = 0.00154000
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 4.62
+			Ratio = 3.08
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000002
+			Ratio = 0.0000040
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000002
+			Ratio = 0.0000040
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -112,38 +112,38 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Substrate
-			Ratio =  0.00430000
+			Ratio =  0.00280000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio =  0.00430000
+			Ratio =  0.00280000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00004300
+			Ratio =  0.00002800
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.00043000
+			Ratio = 0.00028000
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 9.07
+			Ratio = 5.91
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000002
+			Ratio = 0.0000040
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000002
+			Ratio = 0.0000040
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -166,38 +166,38 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Dirt
-			Ratio =  0.00450000
+			Ratio =  0.00300000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio =  0.00450000
+			Ratio =  0.00300000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00001800
+			Ratio =  0.00001200
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Supplies
-			Ratio = 0.00018000
+			Ratio = 0.00012000
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 9.2
+			Ratio = 6.13
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000002
+			Ratio = 0.0000040
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000002
+			Ratio = 0.0000040
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -220,39 +220,39 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Substrate
-			Ratio =  0.00375000
+			Ratio =  0.00263000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio =  0.00375000
+			Ratio =  0.00263000
 		}
 
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00001500
+			Ratio =  0.00001050
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Organics
-			Ratio = 0.00045000
+			Ratio = 0.00052500
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 8.57
+			Ratio = 5.79
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000002
+			Ratio = 0.0000040
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000002
+			Ratio = 0.0000040
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -280,38 +280,38 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = Dirt
-			Ratio =  0.00415000
+			Ratio =  0.00285000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio =  0.00415000
+			Ratio =  0.00285000
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Fertilizer
-			Ratio =  0.00000830
+			Ratio =  0.00000570
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Organics
-			Ratio = 0.000083
+			Ratio = 0.00028500
 			DumpExcess = False
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 9.06
+			Ratio = 5.99
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000002
+			Ratio = 0.0000040
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000002
+			Ratio = 0.0000040
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -337,8 +337,8 @@
 	RESOURCE
 	{
 		name = Machinery
-		amount = 100
-		maxAmount = 100
+		amount = 200
+		maxAmount = 200
 		isTweakable = true
 	}
 	RESOURCE

--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Habitat.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Habitat.cfg
@@ -1,0 +1,154 @@
+//
+// bonuses for the logistics module
+//
+@PART[Benjee10_MMSEV_logisticsShort]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+}
+
+
+
+
+//
+// bonuses for the long logistics module
+//
+@PART[Benjee10_MMSEV_logisticslong]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+}
+
+//
+// bonuses for the big hab module
+//
+@PART[Benjee10_MMSEV_baseHDU_hab]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+}
+
+
+//
+// bonuses for the inflatable hab module
+//
+@PART[Benjee10_base_HDU_attic]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+}
+
+//
+// bonuses for the short hab module
+//
+@PART[Benjee10_MMSEV_baseHabShort]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+}
+
+//
+// bonuses for the long hab module
+//
+@PART[Benjee10_MMSEV_baseHabLong]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// colonization bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = RepBoost	
+		ApplyBonuses = false
+	}
+	
+	// gives colonization rewards
+	MODULE
+	{
+		name = ModuleColonyRewards
+	}
+	
+	// ground tether
+	MODULE
+	{
+		name = USI_InertialDampener
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Science.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/MKS/MMSEV_MKS_Science.cfg
@@ -1,0 +1,18 @@
+//
+// bonuses for the science lab
+//
+@PART[Benjee10_MMSEV_baseLab]:FOR[PlanetsideExplorationTechnologies]:NEEDS[MKS]
+{
+	// benefits from and provides colony bonuses
+	MODULE
+	{
+		name = MKSModule
+		BonusEffect = ScienceBoost
+	}
+	
+	// can participate in local logistics (scavenging)
+	MODULE
+	{
+		name = ModuleLogisticsConsumer
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Command.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Command.cfg
@@ -1,0 +1,174 @@
+//
+// life support for the rover command module
+//
+@PART[Benjee10_MMSEV]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat
+
+		BaseKerbalMonths = 0
+		CrewCapacity = 1
+		BaseHabMultiplier = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.0125
+		}
+	}
+}
+
+
+//
+// life support for the command cabin - based on Ranger MiniHab
+//
+@PART[Benjee10_MMSEV_baseLander]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 20
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.25
+		}
+	}	
+}
+
+
+//
+// life support for the largest command node module - based on Duna Kerbitat and Duna Kolonist
+//
+@PART[Benjee10_MMSEV_baseHDU]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,27,MaterialKits,135,ElectricCharge,135
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Recycler
+		StartActionName = Start Recycler
+		StopActionName = Stop Recycler
+
+		CrewCapacity = 6
+		RecyclePercent = 0.77
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 21
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Purifier
+		StartActionName = Start Purifier
+		StopActionName = Stop Purifier
+
+		CrewCapacity = 6
+		RecyclePercent = 0.885
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 21
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Water
+			Ratio = 0.00885
+		}
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat
+
+		BaseKerbalMonths = 0
+		CrewCapacity = 6
+		BaseHabMultiplier = 1.4
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.14
+		}
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportExtenderSwapOption
+		ConverterName = Living Module
+		StartActionName = Start Living Module
+		StopActionName = Stop Living Module
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 3
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ColonySupplies
+			Ratio = 0.000139
+		}
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Command.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Command.cfg
@@ -20,19 +20,19 @@
 	}
 	MODULE
 	{
-		name = USILS_HabitationSwapOption
-		ConverterName = Habitat
-		StartActionName = Start Habitat
-		StopActionName = Stop Habitat
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
 
-		BaseKerbalMonths = 0
-		CrewCapacity = 1
-		BaseHabMultiplier = 0.5
+					  
+		CrewCapacity = 4
+		RecyclePercent = 0.5
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.0125
+			Ratio = 1.00
 		}
 	}
 }
@@ -65,16 +65,33 @@
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat		
 
-		BaseKerbalMonths = 20
-		CrewCapacity = 0
-		BaseHabMultiplier = 0
+		BaseKerbalMonths = 0
+		CrewCapacity = 2
+		BaseHabMultiplier = 1.8
+
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.25
+			Ratio = 0.15
 		}
-	}	
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 4
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.5
+		}
+	}
 }
 
 
@@ -107,12 +124,12 @@
 		StopActionName = Stop Recycler
 
 		CrewCapacity = 6
-		RecyclePercent = 0.77
+		RecyclePercent = 0.70
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 21
+			Ratio = 10.5
 		}
 	}
 	MODULE
@@ -123,17 +140,17 @@
 		StopActionName = Stop Purifier
 
 		CrewCapacity = 6
-		RecyclePercent = 0.885
+		RecyclePercent = 0.85
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 21
+			Ratio = 10.5
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Water
-			Ratio = 0.00885
+			Ratio = 0.00850
 		}
 	}
 	MODULE
@@ -145,12 +162,12 @@
 
 		BaseKerbalMonths = 0
 		CrewCapacity = 6
-		BaseHabMultiplier = 1.4
+		BaseHabMultiplier = 1.2
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.14
+			Ratio = 0.18
 		}
 	}
 	MODULE
@@ -163,12 +180,12 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 3
+			Ratio = 18
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = ColonySupplies
-			Ratio = 0.000139
+			Ratio = 0.000833
 		}
 	}
 }

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Converters.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Converters.cfg
@@ -1,0 +1,77 @@
+//
+// Life support for the hydroponics module.
+// This is the 'light' version - if MKS is installed then the MKS patch will 
+// default to the more complex version based on the Tundra module
+//
+@PART[Benjee10_MMSEV_baseGreenhouse]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport&!MKS]
+{
+		MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USI_ConverterSwapOption
+		ConverterName = Agroponics
+		StartActionName = Start Agroponics
+		StopActionName = Stop Agroponics
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Mulch
+			Ratio =  0.00210000
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Fertilizer
+			Ratio =  0.00210000
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Supplies
+			Ratio = 0.00231000
+			DumpExcess = False
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 4.62
+		}
+	}
+	RESOURCE
+	{
+		name = Supplies
+		amount = 0
+		maxAmount = 500
+	}
+	RESOURCE
+	{
+		name = Fertilizer
+		amount = 0
+		maxAmount = 500
+	}
+	RESOURCE
+	{
+		name = Mulch
+		amount = 0
+		maxAmount = 500
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 1000
+		maxAmount = 1000
+	}
+	
+}

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Habitat.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Habitat.cfg
@@ -1,0 +1,436 @@
+//
+//  life support for the logistics module
+//
+@PART[Benjee10_MMSEV_logisticsShort]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 20
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.25
+		}
+	}
+}
+
+
+//
+//  life support for the long logistics module
+//
+@PART[Benjee10_MMSEV_logisticslong]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
+		BaseKerbalMonths = 20
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.25
+		}
+	}
+}
+
+//
+//  life support for the big hab module - based on Ranger Hab
+//
+@PART[Benjee10_MMSEV_baseHDU_hab]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,61,MaterialKits,305,ElectricCharge,305
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common		
+
+		BaseKerbalMonths = 16.8
+		CrewCapacity = 4
+		BaseHabMultiplier = 5.2
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.94
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}		
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters		
+
+		BaseKerbalMonths = 80
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2.09
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}
+	}
+}
+
+
+//
+//  life support for the inflatable hab module - based on Ranger Hab
+//
+@PART[Benjee10_base_HDU_attic]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,61,MaterialKits,305,ElectricCharge,305
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common		
+
+		BaseKerbalMonths = 8
+		CrewCapacity = 4
+		BaseHabMultiplier = 5.2
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.94
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}		
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters		
+
+		BaseKerbalMonths = 40
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2.09
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}
+	}
+	
+}
+
+//
+// life support for the short hab module - based on Ranger Hab
+//
+@PART[Benjee10_MMSEV_baseHabShort]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,61,MaterialKits,305,ElectricCharge,305
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common		
+
+		BaseKerbalMonths = 16.8
+		CrewCapacity = 4
+		BaseHabMultiplier = 5.2
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.94
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}		
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters		
+
+		BaseKerbalMonths = 80
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2.09
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}
+	}
+}
+
+//
+// life support for the long hab module - based on Ranger Hab
+//
+@PART[Benjee10_MMSEV_baseHabLong]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+	MODULE
+	{
+		name = USI_SwapController 
+		ResourceCosts = SpecializedParts,61,MaterialKits,305,ElectricCharge,305
+	}
+	MODULE
+	{
+		name = USI_SwappableBay 
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common		
+
+		BaseKerbalMonths = 16.8
+		CrewCapacity = 4
+		BaseHabMultiplier = 5.2
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.94
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}		
+	}
+	MODULE
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Hab-Quarters
+		StartActionName = Start Hab-Quarters
+		StopActionName = Stop Hab-Quarters		
+
+		BaseKerbalMonths = 80
+		CrewCapacity = 0
+		BaseHabMultiplier = 0
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 2.09
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 0.000004
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Recyclables
+			Ratio = 0.000004
+			DumpExcess = true
+		}
+		REQUIRED_RESOURCE
+		{
+			ResourceName = Machinery
+			Ratio = 200
+		}
+	}
+}

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Habitat.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Habitat.cfg
@@ -21,21 +21,21 @@
 	MODULE 
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = Habitat
-		StartActionName = Start Habitat
-		StopActionName = Stop Habitat		
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common	
 
-		BaseKerbalMonths = 20
-		CrewCapacity = 0
-		BaseHabMultiplier = 0
+		BaseKerbalMonths = 0
+		CrewCapacity = 1
+		BaseHabMultiplier = 1.7
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.25
+			Ratio = 0.043
 		}
 	}
-}
+}	
 
 
 //
@@ -61,18 +61,18 @@
 	MODULE 
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = Habitat
-		StartActionName = Start Habitat
-		StopActionName = Stop Habitat		
+		ConverterName = Hab-Common
+		StartActionName = Start Hab-Common
+		StopActionName = Stop Hab-Common		
 
-		BaseKerbalMonths = 20
-		CrewCapacity = 0
-		BaseHabMultiplier = 0
+		BaseKerbalMonths = 0
+		CrewCapacity = 2
+		BaseHabMultiplier = 2.1
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.25
+			Ratio = 0.11
 		}
 	}
 }
@@ -105,14 +105,14 @@
 		StartActionName = Start Hab-Common
 		StopActionName = Stop Hab-Common		
 
-		BaseKerbalMonths = 16.8
+		BaseKerbalMonths = 11
 		CrewCapacity = 4
-		BaseHabMultiplier = 5.2
+		BaseHabMultiplier = 2
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.94
+			Ratio = 0.475
 		}
 		INPUT_RESOURCE
 		{
@@ -139,13 +139,13 @@
 		StopActionName = Stop Hab-Quarters		
 
 		BaseKerbalMonths = 80
-		CrewCapacity = 0
+		CrewCapacity = 4
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.09
+			Ratio = 1.08
 		}
 		INPUT_RESOURCE
 		{
@@ -163,6 +163,18 @@
 			ResourceName = Machinery
 			Ratio = 200
 		}
+	}
+	RESOURCE
+	{
+		name = Machinery
+		amount = 200
+		maxAmount = 200
+	}
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 200
 	}
 }
 
@@ -195,24 +207,24 @@
 		StartActionName = Start Hab-Common
 		StopActionName = Stop Hab-Common		
 
-		BaseKerbalMonths = 8
+		BaseKerbalMonths = 4
 		CrewCapacity = 4
-		BaseHabMultiplier = 5.2
+		BaseHabMultiplier = 1.5
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.94
+			Ratio = 0.25
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000004
+			Ratio = 0.000002
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000004
+			Ratio = 0.000002
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -228,24 +240,24 @@
 		StartActionName = Start Hab-Quarters
 		StopActionName = Stop Hab-Quarters		
 
-		BaseKerbalMonths = 40
-		CrewCapacity = 0
+		BaseKerbalMonths = 20
+		CrewCapacity = 4
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.09
+			Ratio = 0.5
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000004
+			Ratio = 0.000002
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000004
+			Ratio = 0.000002
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -254,7 +266,18 @@
 			Ratio = 200
 		}
 	}
-	
+	RESOURCE
+	{
+		name = Machinery
+		amount = 100
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 100
+	}
 }
 
 //
@@ -281,61 +304,61 @@
 	MODULE
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = Hab-Common
-		StartActionName = Start Hab-Common
-		StopActionName = Stop Hab-Common		
+							
+									
+									
 
-		BaseKerbalMonths = 16.8
-		CrewCapacity = 4
-		BaseHabMultiplier = 5.2
+						 
+				  
+						 
 
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.94
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.000004
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.000004
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 200
-		}		
-	}
-	MODULE
-	{
-		name = USILS_HabitationSwapOption
+				
+   
+								
+			   
+   
+				
+   
+						   
+				   
+   
+				 
+   
+							 
+				   
+					
+   
+				   
+   
+						   
+			  
+	 
+  
+	   
+  
+								   
 		ConverterName = Hab-Quarters
 		StartActionName = Start Hab-Quarters
 		StopActionName = Stop Hab-Quarters		
 
-		BaseKerbalMonths = 80
+		BaseKerbalMonths = 5
 		CrewCapacity = 0
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.09
+			Ratio = 0.13
 		}
 		INPUT_RESOURCE
 		{
 			ResourceName = Machinery
-			Ratio = 0.000004
+			Ratio = 0.000001
 		}
 		OUTPUT_RESOURCE
 		{
 			ResourceName = Recyclables
-			Ratio = 0.000004
+			Ratio = 0.000001
 			DumpExcess = true
 		}
 		REQUIRED_RESOURCE
@@ -343,6 +366,18 @@
 			ResourceName = Machinery
 			Ratio = 200
 		}
+	}
+	RESOURCE
+	{
+		name = Machinery
+		amount = 50
+		maxAmount = 50
+	}
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 50
 	}
 }
 
@@ -370,51 +405,51 @@
 	MODULE
 	{
 		name = USILS_HabitationSwapOption
-		ConverterName = Hab-Common
-		StartActionName = Start Hab-Common
-		StopActionName = Stop Hab-Common		
+							
+									
+									
 
-		BaseKerbalMonths = 16.8
-		CrewCapacity = 4
-		BaseHabMultiplier = 5.2
+						 
+				  
+						 
 
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 0.94
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 0.000004
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Recyclables
-			Ratio = 0.000004
-			DumpExcess = true
-		}
-		REQUIRED_RESOURCE
-		{
-			ResourceName = Machinery
-			Ratio = 200
-		}		
-	}
-	MODULE
-	{
-		name = USILS_HabitationSwapOption
+				
+   
+								
+			   
+   
+				
+   
+						   
+				   
+   
+				 
+   
+							 
+				   
+					
+   
+				   
+   
+						   
+			  
+	 
+  
+	   
+  
+								   
 		ConverterName = Hab-Quarters
 		StartActionName = Start Hab-Quarters
 		StopActionName = Stop Hab-Quarters		
 
-		BaseKerbalMonths = 80
+		BaseKerbalMonths = 7.5
 		CrewCapacity = 0
 		BaseHabMultiplier = 0
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.09
+			Ratio = 0.19
 		}
 		INPUT_RESOURCE
 		{
@@ -432,5 +467,17 @@
 			ResourceName = Machinery
 			Ratio = 200
 		}
+	}
+	RESOURCE
+	{
+		name = Machinery
+		amount = 100
+		maxAmount = 100
+	}
+	RESOURCE
+	{
+		name = Recyclables
+		amount = 0
+		maxAmount = 100
 	}
 }

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Science.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Science.cfg
@@ -1,0 +1,37 @@
+//
+// life support for the science lab
+//
+@PART[Benjee10_MMSEV_baseLab]:FOR[PlanetsideExplorationTechnologies]:NEEDS[USILifeSupport]
+{
+MODULE
+	{
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 2
+		RecyclePercent = .6
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = .5
+		}
+	}	
+}

--- a/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Science.cfg
+++ b/GameData/Benjee10_MMSEV/Patches/USI-LS/MMSEV_USI_LS_Science.cfg
@@ -26,12 +26,12 @@ MODULE
 		StopActionName = Stop Life Support
 
 		CrewCapacity = 2
-		RecyclePercent = .6
+		RecyclePercent = 0.7
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = .5
+			Ratio = 3.5
 		}
 	}	
 }


### PR DESCRIPTION
A patch to add support for MKS and USI-LS.

I did some basic testing by throwing Jeb against the habitat walls. MM reports that all is peachy. But more testing is required, and definitely a balance pass. I basically looked at the nearest MKS equivalent modules in terms of mass to get a clue for how to configure this. 

The hydroponics module has two configurations - a simple one for when only USI-LS is installed without MKS, and a more hardcore one for when MKS is installed.

The configurations are largely based on how MKS configures itself so credit and props to RoverDude for his work. 